### PR TITLE
chore(security): patch fast-uri to 3.1.1 (GHSA-q3j6-qgpj-74h6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8253,9 +8253,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
+      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "minimatch": "10.2.4",
     "serialize-javascript": "7.0.5",
     "picomatch": "4.0.4",
-    "node-forge": "1.4.0"
+    "node-forge": "1.4.0",
+    "fast-uri": "3.1.1"
   }
 }


### PR DESCRIPTION
Automated heartbeat security patch for Dependabot alert #65 (CVE-2026-6321).\n\n- adds npm override: fast-uri=3.1.1\n- refreshes package-lock.json\n\nPlease review and merge.